### PR TITLE
fix(Web): fixed date formatting of member creation date in the member details view

### DIFF
--- a/src/Kentico.Community.Portal.Web/Components/ViewComponents/Navigation/Navigation.cshtml
+++ b/src/Kentico.Community.Portal.Web/Components/ViewComponents/Navigation/Navigation.cshtml
@@ -138,7 +138,6 @@
             }
         </ul>
     </div>
-    </div>
 
     <vc:alert-box />
 

--- a/src/Kentico.Community.Portal.Web/Features/Members/MemberDetail.cshtml
+++ b/src/Kentico.Community.Portal.Web/Features/Members/MemberDetail.cshtml
@@ -28,7 +28,7 @@
                                     </p>
                                 }
                                 <p>
-                                    Joined: @member.Created.ToShortDateString()
+                                    Joined: @member.Created.ToString("d", View.Culture)
                                 </p>
                                 @if (!string.IsNullOrWhiteSpace(member.LinkedInIdentifier))
                                 {


### PR DESCRIPTION
# Motivation

- Changed the formatting of the member creation date from using the default short date format to utilizing the "d" format specifier with the current UI culture. This ensures consistent date presentation across different cultures within the view.
- Removed stray closing div in the navigation, as highlighted by the W3C Markup Validator

## Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

If manual testing is required, what are the steps?
