### PR TITLE
Add confirmation message to question submit form

### DIFF
--- a/src/Kentico.Community.Portal.Web/Features/QAndA/Components/Form/QAndAQuestionFormConfirmation.cshtml
+++ b/src/Kentico.Community.Portal.Web/Features/QAndA/Components/Form/QAndAQuestionFormConfirmation.cshtml
@@ -1,0 +1,5 @@
+<div class="alert alert-success" role="alert">
+    Your question has been successfully submitted!<br><br>
+    It may take a few moments for the <a href="/q-and-a">Q&A listing</a> to update, don't worry if you don't see it
+    right away.
+</div>


### PR DESCRIPTION
# Motivation

At the moment, when you submit a new question to the [Q&A](https://community.kentico.com/q-and-a), it can be confusing if the question does not appear immediately as you are taken straight to the listing without any messaging.

Now when the form has successfully submitted a new question, it is replaced with a confirmation message advising you that the question may not appear immediately.