### PR TITLE
feat: Add API for Community Leader Activity submissions

### DIFF
--- a/src/Kentico.Community.Portal.Web/Features/Api/CommunityLeaderActivityController.cs
+++ b/src/Kentico.Community.Portal.Web/Features/Api/CommunityLeaderActivityController.cs
@@ -1,0 +1,350 @@
+using CMS.Membership;
+using CMS.OnlineForms;
+using Kentico.Community.Portal.Core.Forms;
+using Kentico.Membership;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Kentico.Community.Portal.Web.Features.Api;
+
+/// <summary>
+/// API endpoints for Community Leader Activity submissions.
+/// Allows authenticated members to submit their community activities (blogs, social posts, etc.)
+/// without using the web form.
+/// </summary>
+[ApiController]
+[Route("api/community-leader-activity")]
+[Authorize] // Requires authenticated member session
+public class CommunityLeaderActivityController(
+    ILogger<CommunityLeaderActivityController> logger,
+    IBizFormInfoProvider bizFormInfoProvider,
+    UserManager<ApplicationUser> userManager,
+    IMemberInfoProvider memberInfoProvider)
+    : ControllerBase
+{
+    private readonly ILogger<CommunityLeaderActivityController> logger = logger;
+    private readonly IBizFormInfoProvider bizFormInfoProvider = bizFormInfoProvider;
+    private readonly UserManager<ApplicationUser> userManager = userManager;
+    private readonly IMemberInfoProvider memberInfoProvider = memberInfoProvider;
+
+    /// <summary>
+    /// Creates a new Community Leader Activity form submission for the authenticated member
+    /// </summary>
+    [HttpPost]
+    [Consumes("application/json")]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(CreateActivityResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> CreateActivity([FromBody] CreateActivityRequest request)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        // Get authenticated member
+        var user = await userManager.GetUserAsync(User);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        var member = await memberInfoProvider.GetAsync(user.Id);
+        if (member is null)
+        {
+            logger.LogWarning("User {UserId} has no associated member", user.Id);
+            return Problem("Member profile not found", statusCode: 400);
+        }
+
+        try
+        {
+            var formInfo = await bizFormInfoProvider.GetAsync("CommunityLeaderActivity");
+            if (formInfo is null)
+            {
+                logger.LogError("CommunityLeaderActivity form not found");
+                return Problem("Form configuration not found", statusCode: 500);
+            }
+
+            var item = new CommunityLeaderActivityItem
+            {
+                MemberID = member.MemberID,
+                MemberEmail = member.MemberEmail,
+                ActivityDate = request.ActivityDate ?? DateTime.UtcNow,
+                ActivityType = request.ActivityType ?? "Social",
+                URL = request.Url,
+                ShortDescription = request.ShortDescription,
+                Impact = request.Impact ?? "3",
+                Effort = request.Effort ?? "2",
+                Satisfaction = request.Satisfaction ?? "3"
+            };
+
+            item.Insert();
+
+            logger.LogInformation(
+                "Created CommunityLeaderActivity {ItemId} for member {MemberId} ({MemberEmail})",
+                item.ItemID,
+                member.MemberID,
+                member.MemberEmail);
+
+            var response = new CreateActivityResponse
+            {
+                Id = item.ItemID,
+                Message = "Activity created successfully"
+            };
+
+            return CreatedAtAction(
+                nameof(GetActivity),
+                new { id = item.ItemID },
+                response);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to create CommunityLeaderActivity for member {MemberId}", member.MemberID);
+            return Problem("Failed to create activity", statusCode: 500);
+        }
+    }
+
+    /// <summary>
+    /// Gets a Community Leader Activity by ID (only your own activities)
+    /// </summary>
+    [HttpGet("{id:int}")]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(ActivityResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetActivity(int id)
+    {
+        var user = await userManager.GetUserAsync(User);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        var member = await memberInfoProvider.GetAsync(user.Id);
+        if (member is null)
+        {
+            return Unauthorized();
+        }
+
+        var item = await BizFormItemProvider
+            .GetItems<CommunityLeaderActivityItem>()
+            .WhereEquals(nameof(CommunityLeaderActivityItem.ItemID), id)
+            .WhereEquals(nameof(CommunityLeaderActivityItem.MemberID), member.MemberID)
+            .FirstOrDefaultAsync();
+
+        if (item is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(new ActivityResponse
+        {
+            Id = item.ItemID,
+            ActivityDate = item.ActivityDate,
+            ActivityType = item.ActivityType,
+            Url = item.URL,
+            ShortDescription = item.ShortDescription,
+            Impact = item.Impact,
+            Effort = item.Effort,
+            Satisfaction = item.Satisfaction
+        });
+    }
+
+    /// <summary>
+    /// Lists your Community Leader Activities
+    /// </summary>
+    [HttpGet]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(List<ActivityResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> ListActivities([FromQuery] int limit = 50, [FromQuery] int offset = 0)
+    {
+        var user = await userManager.GetUserAsync(User);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        var member = await memberInfoProvider.GetAsync(user.Id);
+        if (member is null)
+        {
+            return Unauthorized();
+        }
+
+        var items = await BizFormItemProvider
+            .GetItems<CommunityLeaderActivityItem>()
+            .WhereEquals(nameof(CommunityLeaderActivityItem.MemberID), member.MemberID)
+            .OrderByDescending(nameof(CommunityLeaderActivityItem.ActivityDate))
+            .Skip(offset)
+            .Take(Math.Min(limit, 100))
+            .ToListAsync();
+
+        var response = items.Select(item => new ActivityResponse
+        {
+            Id = item.ItemID,
+            ActivityDate = item.ActivityDate,
+            ActivityType = item.ActivityType,
+            Url = item.URL,
+            ShortDescription = item.ShortDescription,
+            Impact = item.Impact,
+            Effort = item.Effort,
+            Satisfaction = item.Satisfaction
+        }).ToList();
+
+        return Ok(response);
+    }
+
+    /// <summary>
+    /// Creates multiple Community Leader Activities in batch for the authenticated member
+    /// </summary>
+    [HttpPost("batch")]
+    [Consumes("application/json")]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(BatchCreateResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> CreateActivitiesBatch([FromBody] List<CreateActivityRequest> requests)
+    {
+        if (requests is null || requests.Count == 0)
+        {
+            return BadRequest("No activities provided");
+        }
+
+        if (requests.Count > 100)
+        {
+            return BadRequest("Maximum 100 activities per batch");
+        }
+
+        // Get authenticated member
+        var user = await userManager.GetUserAsync(User);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        var member = await memberInfoProvider.GetAsync(user.Id);
+        if (member is null)
+        {
+            return Problem("Member profile not found", statusCode: 400);
+        }
+
+        var formInfo = await bizFormInfoProvider.GetAsync("CommunityLeaderActivity");
+        if (formInfo is null)
+        {
+            return Problem("Form configuration not found", statusCode: 500);
+        }
+
+        var createdIds = new List<int>();
+        var errors = new List<string>();
+
+        foreach (var (request, index) in requests.Select((r, i) => (r, i)))
+        {
+            try
+            {
+                var item = new CommunityLeaderActivityItem
+                {
+                    MemberID = member.MemberID,
+                    MemberEmail = member.MemberEmail,
+                    ActivityDate = request.ActivityDate ?? DateTime.UtcNow,
+                    ActivityType = request.ActivityType ?? "Social",
+                    URL = request.Url,
+                    ShortDescription = request.ShortDescription,
+                    Impact = request.Impact ?? "3",
+                    Effort = request.Effort ?? "2",
+                    Satisfaction = request.Satisfaction ?? "3"
+                };
+
+                item.Insert();
+                createdIds.Add(item.ItemID);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to create activity at index {Index} for member {MemberId}", index, member.MemberID);
+                errors.Add($"Item {index}: {ex.Message}");
+            }
+        }
+
+        logger.LogInformation(
+            "Batch created {Count} activities for member {MemberId}",
+            createdIds.Count,
+            member.MemberID);
+
+        return Created("", new BatchCreateResponse
+        {
+            CreatedIds = createdIds,
+            CreatedCount = createdIds.Count,
+            ErrorCount = errors.Count,
+            Errors = errors
+        });
+    }
+}
+
+/// <summary>
+/// Request model for creating a community leader activity
+/// </summary>
+public class CreateActivityRequest
+{
+    /// <summary>
+    /// Date of the activity (defaults to now if not provided)
+    /// </summary>
+    public DateTime? ActivityDate { get; set; }
+
+    /// <summary>
+    /// Type of activity: Social, Blog, Video, Presentation, Podcast, Other
+    /// </summary>
+    public string? ActivityType { get; set; } = "Social";
+
+    /// <summary>
+    /// URL to the content (required)
+    /// </summary>
+    public required string Url { get; set; }
+
+    /// <summary>
+    /// Brief description of the activity (required)
+    /// </summary>
+    public required string ShortDescription { get; set; }
+
+    /// <summary>
+    /// Impact rating: 1-5 (default: 3)
+    /// </summary>
+    public string? Impact { get; set; } = "3";
+
+    /// <summary>
+    /// Effort rating: 1-5 (default: 2)
+    /// </summary>
+    public string? Effort { get; set; } = "2";
+
+    /// <summary>
+    /// Satisfaction rating: 1-5 (default: 3)
+    /// </summary>
+    public string? Satisfaction { get; set; } = "3";
+}
+
+public class CreateActivityResponse
+{
+    public int Id { get; set; }
+    public string Message { get; set; } = "";
+}
+
+public class ActivityResponse
+{
+    public int Id { get; set; }
+    public DateTime ActivityDate { get; set; }
+    public string ActivityType { get; set; } = "";
+    public string Url { get; set; } = "";
+    public string ShortDescription { get; set; } = "";
+    public string Impact { get; set; } = "";
+    public string Effort { get; set; } = "";
+    public string Satisfaction { get; set; } = "";
+}
+
+public class BatchCreateResponse
+{
+    public List<int> CreatedIds { get; set; } = [];
+    public int CreatedCount { get; set; }
+    public int ErrorCount { get; set; }
+    public List<string> Errors { get; set; } = [];
+}

--- a/src/Kentico.Community.Portal.Web/Features/Api/CommunityLeaderActivityController.cs
+++ b/src/Kentico.Community.Portal.Web/Features/Api/CommunityLeaderActivityController.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using CMS.Membership;
 using CMS.OnlineForms;
 using Kentico.Community.Portal.Core.Forms;
@@ -13,9 +14,12 @@ namespace Kentico.Community.Portal.Web.Features.Api;
 /// Allows authenticated members to submit their community activities (blogs, social posts, etc.)
 /// without using the web form.
 /// </summary>
+/// <remarks>
+/// Requires the X-Requested-With header for CSRF protection on state-changing operations.
+/// </remarks>
 [ApiController]
 [Route("api/community-leader-activity")]
-[Authorize] // Requires authenticated member session
+[Authorize]
 public class CommunityLeaderActivityController(
     ILogger<CommunityLeaderActivityController> logger,
     IBizFormInfoProvider bizFormInfoProvider,
@@ -23,6 +27,9 @@ public class CommunityLeaderActivityController(
     IMemberInfoProvider memberInfoProvider)
     : ControllerBase
 {
+    private const string CSRF_HEADER = "X-Requested-With";
+    private const string CSRF_HEADER_VALUE = "XMLHttpRequest";
+
     private readonly ILogger<CommunityLeaderActivityController> logger = logger;
     private readonly IBizFormInfoProvider bizFormInfoProvider = bizFormInfoProvider;
     private readonly UserManager<ApplicationUser> userManager = userManager;
@@ -37,27 +44,26 @@ public class CommunityLeaderActivityController(
     [ProducesResponseType(typeof(CreateActivityResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> CreateActivity([FromBody] CreateActivityRequest request)
     {
-        if (!ModelState.IsValid)
+        if (!ValidateCsrfHeader())
         {
-            return BadRequest(ModelState);
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Missing CSRF header",
+                Detail = $"The {CSRF_HEADER} header is required for this request"
+            });
         }
 
-        // Get authenticated member
-        var user = await userManager.GetUserAsync(User);
-        if (user is null)
+        var memberResult = await GetAuthenticatedMemberAsync();
+        if (memberResult.ActionResult is not null)
         {
-            return Unauthorized();
+            return memberResult.ActionResult;
         }
 
-        var member = await memberInfoProvider.GetAsync(user.Id);
-        if (member is null)
-        {
-            logger.LogWarning("User {UserId} has no associated member", user.Id);
-            return Problem("Member profile not found", statusCode: 400);
-        }
+        var member = memberResult.Member!;
 
         try
         {
@@ -65,22 +71,10 @@ public class CommunityLeaderActivityController(
             if (formInfo is null)
             {
                 logger.LogError("CommunityLeaderActivity form not found");
-                return Problem("Form configuration not found", statusCode: 500);
+                return Problem("Form configuration not found", statusCode: StatusCodes.Status500InternalServerError);
             }
 
-            var item = new CommunityLeaderActivityItem
-            {
-                MemberID = member.MemberID,
-                MemberEmail = member.MemberEmail,
-                ActivityDate = request.ActivityDate ?? DateTime.UtcNow,
-                ActivityType = request.ActivityType ?? "Social",
-                URL = request.Url,
-                ShortDescription = request.ShortDescription,
-                Impact = request.Impact ?? "3",
-                Effort = request.Effort ?? "2",
-                Satisfaction = request.Satisfaction ?? "3"
-            };
-
+            var item = CreateActivityItem(request, member);
             item.Insert();
 
             logger.LogInformation(
@@ -103,7 +97,7 @@ public class CommunityLeaderActivityController(
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to create CommunityLeaderActivity for member {MemberId}", member.MemberID);
-            return Problem("Failed to create activity", statusCode: 500);
+            return Problem("Failed to create activity", statusCode: StatusCodes.Status500InternalServerError);
         }
     }
 
@@ -114,20 +108,17 @@ public class CommunityLeaderActivityController(
     [Produces("application/json")]
     [ProducesResponseType(typeof(ActivityResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetActivity(int id)
     {
-        var user = await userManager.GetUserAsync(User);
-        if (user is null)
+        var memberResult = await GetAuthenticatedMemberAsync();
+        if (memberResult.ActionResult is not null)
         {
-            return Unauthorized();
+            return memberResult.ActionResult;
         }
 
-        var member = await memberInfoProvider.GetAsync(user.Id);
-        if (member is null)
-        {
-            return Unauthorized();
-        }
+        var member = memberResult.Member!;
 
         var item = await BizFormItemProvider
             .GetItems<CommunityLeaderActivityItem>()
@@ -140,17 +131,7 @@ public class CommunityLeaderActivityController(
             return NotFound();
         }
 
-        return Ok(new ActivityResponse
-        {
-            Id = item.ItemID,
-            ActivityDate = item.ActivityDate,
-            ActivityType = item.ActivityType,
-            Url = item.URL,
-            ShortDescription = item.ShortDescription,
-            Impact = item.Impact,
-            Effort = item.Effort,
-            Satisfaction = item.Satisfaction
-        });
+        return Ok(MapToResponse(item));
     }
 
     /// <summary>
@@ -160,19 +141,16 @@ public class CommunityLeaderActivityController(
     [Produces("application/json")]
     [ProducesResponseType(typeof(List<ActivityResponse>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> ListActivities([FromQuery] int limit = 50, [FromQuery] int offset = 0)
     {
-        var user = await userManager.GetUserAsync(User);
-        if (user is null)
+        var memberResult = await GetAuthenticatedMemberAsync();
+        if (memberResult.ActionResult is not null)
         {
-            return Unauthorized();
+            return memberResult.ActionResult;
         }
 
-        var member = await memberInfoProvider.GetAsync(user.Id);
-        if (member is null)
-        {
-            return Unauthorized();
-        }
+        var member = memberResult.Member!;
 
         var items = await BizFormItemProvider
             .GetItems<CommunityLeaderActivityItem>()
@@ -182,17 +160,7 @@ public class CommunityLeaderActivityController(
             .Take(Math.Min(limit, 100))
             .ToListAsync();
 
-        var response = items.Select(item => new ActivityResponse
-        {
-            Id = item.ItemID,
-            ActivityDate = item.ActivityDate,
-            ActivityType = item.ActivityType,
-            Url = item.URL,
-            ShortDescription = item.ShortDescription,
-            Impact = item.Impact,
-            Effort = item.Effort,
-            Satisfaction = item.Satisfaction
-        }).ToList();
+        var response = items.Select(MapToResponse).ToList();
 
         return Ok(response);
     }
@@ -206,35 +174,48 @@ public class CommunityLeaderActivityController(
     [ProducesResponseType(typeof(BatchCreateResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> CreateActivitiesBatch([FromBody] List<CreateActivityRequest> requests)
     {
+        if (!ValidateCsrfHeader())
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Missing CSRF header",
+                Detail = $"The {CSRF_HEADER} header is required for this request"
+            });
+        }
+
         if (requests is null || requests.Count == 0)
         {
-            return BadRequest("No activities provided");
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid request",
+                Detail = "No activities provided"
+            });
         }
 
         if (requests.Count > 100)
         {
-            return BadRequest("Maximum 100 activities per batch");
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid request",
+                Detail = "Maximum 100 activities per batch"
+            });
         }
 
-        // Get authenticated member
-        var user = await userManager.GetUserAsync(User);
-        if (user is null)
+        var memberResult = await GetAuthenticatedMemberAsync();
+        if (memberResult.ActionResult is not null)
         {
-            return Unauthorized();
+            return memberResult.ActionResult;
         }
 
-        var member = await memberInfoProvider.GetAsync(user.Id);
-        if (member is null)
-        {
-            return Problem("Member profile not found", statusCode: 400);
-        }
+        var member = memberResult.Member!;
 
         var formInfo = await bizFormInfoProvider.GetAsync("CommunityLeaderActivity");
         if (formInfo is null)
         {
-            return Problem("Form configuration not found", statusCode: 500);
+            return Problem("Form configuration not found", statusCode: StatusCodes.Status500InternalServerError);
         }
 
         var createdIds = new List<int>();
@@ -244,26 +225,14 @@ public class CommunityLeaderActivityController(
         {
             try
             {
-                var item = new CommunityLeaderActivityItem
-                {
-                    MemberID = member.MemberID,
-                    MemberEmail = member.MemberEmail,
-                    ActivityDate = request.ActivityDate ?? DateTime.UtcNow,
-                    ActivityType = request.ActivityType ?? "Social",
-                    URL = request.Url,
-                    ShortDescription = request.ShortDescription,
-                    Impact = request.Impact ?? "3",
-                    Effort = request.Effort ?? "2",
-                    Satisfaction = request.Satisfaction ?? "3"
-                };
-
+                var item = CreateActivityItem(request, member);
                 item.Insert();
                 createdIds.Add(item.ItemID);
             }
             catch (Exception ex)
             {
                 logger.LogError(ex, "Failed to create activity at index {Index} for member {MemberId}", index, member.MemberID);
-                errors.Add($"Item {index}: {ex.Message}");
+                errors.Add($"Item {index}: failed to create activity");
             }
         }
 
@@ -280,7 +249,80 @@ public class CommunityLeaderActivityController(
             Errors = errors
         });
     }
+
+    #region Private Helpers
+
+    /// <summary>
+    /// Validates the CSRF header is present for state-changing requests
+    /// </summary>
+    private bool ValidateCsrfHeader()
+    {
+        return Request.Headers.TryGetValue(CSRF_HEADER, out var headerValue)
+            && string.Equals(headerValue.FirstOrDefault(), CSRF_HEADER_VALUE, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Gets the authenticated member, returning appropriate error responses if not found
+    /// </summary>
+    private async Task<(MemberInfo? Member, IActionResult? ActionResult)> GetAuthenticatedMemberAsync()
+    {
+        var user = await userManager.GetUserAsync(User);
+        if (user is null)
+        {
+            return (null, Unauthorized());
+        }
+
+        var member = await memberInfoProvider.GetAsync(user.Id);
+        if (member is null)
+        {
+            logger.LogWarning("User {UserId} has no associated member", user.Id);
+            return (null, Problem("Member profile not found", statusCode: StatusCodes.Status403Forbidden));
+        }
+
+        return (member, null);
+    }
+
+    /// <summary>
+    /// Creates a CommunityLeaderActivityItem from a request and member
+    /// </summary>
+    private static CommunityLeaderActivityItem CreateActivityItem(CreateActivityRequest request, MemberInfo member)
+    {
+        return new CommunityLeaderActivityItem
+        {
+            MemberID = member.MemberID,
+            MemberEmail = member.MemberEmail,
+            ActivityDate = request.ActivityDate ?? DateTime.UtcNow,
+            ActivityType = request.ActivityType ?? "Social",
+            URL = request.Url,
+            ShortDescription = request.ShortDescription,
+            Impact = request.Impact ?? "3",
+            Effort = request.Effort ?? "2",
+            Satisfaction = request.Satisfaction ?? "3"
+        };
+    }
+
+    /// <summary>
+    /// Maps a CommunityLeaderActivityItem to an ActivityResponse
+    /// </summary>
+    private static ActivityResponse MapToResponse(CommunityLeaderActivityItem item)
+    {
+        return new ActivityResponse
+        {
+            Id = item.ItemID,
+            ActivityDate = item.ActivityDate,
+            ActivityType = item.ActivityType,
+            Url = item.URL,
+            ShortDescription = item.ShortDescription,
+            Impact = item.Impact,
+            Effort = item.Effort,
+            Satisfaction = item.Satisfaction
+        };
+    }
+
+    #endregion
 }
+
+#region DTOs
 
 /// <summary>
 /// Request model for creating a community leader activity
@@ -295,31 +337,40 @@ public class CreateActivityRequest
     /// <summary>
     /// Type of activity: Social, Blog, Video, Presentation, Podcast, Other
     /// </summary>
+    [StringLength(50)]
     public string? ActivityType { get; set; } = "Social";
 
     /// <summary>
     /// URL to the content (required)
     /// </summary>
-    public required string Url { get; set; }
+    [Required(ErrorMessage = "URL is required")]
+    [Url(ErrorMessage = "URL must be a valid URL")]
+    [StringLength(500)]
+    public string Url { get; set; } = "";
 
     /// <summary>
     /// Brief description of the activity (required)
     /// </summary>
-    public required string ShortDescription { get; set; }
+    [Required(ErrorMessage = "Short description is required")]
+    [StringLength(500, MinimumLength = 5, ErrorMessage = "Description must be between 5 and 500 characters")]
+    public string ShortDescription { get; set; } = "";
 
     /// <summary>
     /// Impact rating: 1-5 (default: 3)
     /// </summary>
+    [RegularExpression("^[1-5]$", ErrorMessage = "Impact must be between 1 and 5")]
     public string? Impact { get; set; } = "3";
 
     /// <summary>
     /// Effort rating: 1-5 (default: 2)
     /// </summary>
+    [RegularExpression("^[1-5]$", ErrorMessage = "Effort must be between 1 and 5")]
     public string? Effort { get; set; } = "2";
 
     /// <summary>
     /// Satisfaction rating: 1-5 (default: 3)
     /// </summary>
+    [RegularExpression("^[1-5]$", ErrorMessage = "Satisfaction must be between 1 and 5")]
     public string? Satisfaction { get; set; } = "3";
 }
 
@@ -348,3 +399,5 @@ public class BatchCreateResponse
     public int ErrorCount { get; set; }
     public List<string> Errors { get; set; } = [];
 }
+
+#endregion


### PR DESCRIPTION
## Summary

Adds REST API endpoints for Community Leaders to submit their activities (blogs, LinkedIn posts, videos, etc.) programmatically without using the web form.

## Motivation

Community Leaders currently must manually fill out a form for each activity submission. This API enables:
- Programmatic submissions from scripts or tools
- Batch uploads of multiple activities
- Integration with automation workflows

## Changes

**New file:** `src/Kentico.Community.Portal.Web/Features/Api/CommunityLeaderActivityController.cs`

### Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/api/community-leader-activity` | Create a single activity |
| `GET` | `/api/community-leader-activity` | List your activities |
| `GET` | `/api/community-leader-activity/{id}` | Get activity by ID |
| `POST` | `/api/community-leader-activity/batch` | Create up to 100 activities |

### Authentication

Uses existing member authentication (session cookies). Members can only submit and view their own activities.

### Request Example

```json
POST /api/community-leader-activity
{
  "url": "https://linkedin.com/posts/...",
  "shortDescription": "Article about XbK migrations",
  "activityType": "Blog",
  "impact": "3",
  "effort": "2",
  "satisfaction": "3"
}
```

### Response Example

```json
{
  "id": 123,
  "message": "Activity created successfully"
}
```

## Testing

- [ ] Verify authenticated members can submit activities
- [ ] Verify unauthenticated requests return 401
- [ ] Verify members can only view their own activities
- [ ] Verify batch endpoint respects 100-item limit

## Notes

No configuration changes required. Uses existing `CommunityLeaderActivity` BizForm and member authentication infrastructure.